### PR TITLE
CircleCI integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,20 +1,29 @@
+defaults: &defaults
+  working_directory: ~/api-docs
+  docker:
+    - image: circleci/ruby:2.4.1-node-browsers
 version: 2
 jobs:
-  install_and_deploy:
-    docker:
-       - image: circleci/ruby:2.4.1-node-browsers
-
-    working_directory: ~/api-docs
-
+  install:
+    <<: *defaults
     steps:
       - run: bundle install
+  deploy:
+    <<: *defaults
+    steps:
       - run: ./deploy.sh
 
 workflows:
   version: 2
   release:
     jobs:
-      - install_and_deploy:
+      - install:
+          filters:
+            branches:
+              only: ci
+      - deploy:
+          requires:
+            - install
           filters:
             branches:
               only: ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,13 +2,33 @@ defaults: &defaults
   working_directory: ~/api-docs
   docker:
     - image: circleci/ruby:2.4.1-node-browsers
+      environment:
+        BUNDLE_JOBS: 3
+        BUNDLE_RETRY: 3
+        BUNDLE_PATH: vendor/bundle
 version: 2
 jobs:
   install:
     <<: *defaults
     steps:
       - checkout
-      - run: bundle install
+      # Which version of bundler?
+      - run:
+          name: Which bundler?
+          command: bundle -v
+      # Restore bundle cache
+      - restore_cache:
+          keys:
+            - api-docs-bundle-{{ checksum "Gemfile.lock" }}
+            - api-docs-bundle-
+      - run:
+          name: Bundle Install
+          command: bundle check || bundle install
+      # Store bundle cache
+      - save_cache:
+          key: api-docs-bundle-{{ checksum "Gemfile.lock" }}
+          paths:
+            - vendor/bundle
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,20 @@
+version: 2
+jobs:
+  install_and_deploy:
+    docker:
+       - image: circleci/ruby:2.4.1-node-browsers
+
+    working_directory: ~/api-docs
+
+    steps:
+      - run: bundle install
+      - run: ./deploy.sh
+
+workflows:
+  version: 2
+  release:
+    jobs:
+      - install_and_deploy:
+          filters:
+            branches:
+              only: ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,10 +4,6 @@ defaults: &defaults
     - image: circleci/ruby:2.4.1-node-browsers
 version: 2
 jobs:
-  install:
-    <<: *defaults
-    steps:
-      - run: bundle install
   deploy:
     <<: *defaults
     steps:
@@ -17,13 +13,7 @@ workflows:
   version: 2
   release:
     jobs:
-      - install:
-          filters:
-            branches:
-              only: ci
       - deploy:
-          requires:
-            - install
           filters:
             branches:
               only: ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,11 @@ defaults: &defaults
     - image: circleci/ruby:2.4.1-node-browsers
 version: 2
 jobs:
+  install:
+    <<: *defaults
+    steps:
+      - checkout
+      - run: bundle install
   deploy:
     <<: *defaults
     steps:
@@ -13,7 +18,13 @@ workflows:
   version: 2
   release:
     jobs:
+      - install:
+          filters:
+            branches:
+              only: ci
       - deploy:
+          requires:
+            - install
           filters:
             branches:
               only: ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ workflows:
   version: 2
   release:
     jobs:
-      - install:
+      - install
       - build:
           requires:
             - install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,9 +9,17 @@ jobs:
     steps:
       - checkout
       - run: bundle install
-  deploy:
+  build:
     <<: *defaults
     steps:
+      - attach_workspace:
+          at: ~/api-docs
+      - run: bundle exec middleman build --clean
+  build_and_deploy:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ~/api-docs
       - run: ./deploy.sh
 
 workflows:
@@ -19,12 +27,15 @@ workflows:
   release:
     jobs:
       - install:
-          filters:
-            branches:
-              only: ci
-      - deploy:
+      - build:
           requires:
             - install
           filters:
             branches:
-              only: ci
+              ignore: master
+      - build_and_deploy:
+          requires:
+            - install
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,10 @@ jobs:
     steps:
       - checkout
       - run: bundle install
+      - persist_to_workspace:
+          root: .
+          paths:
+            - '*'
   build:
     <<: *defaults
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
 
 workflows:
   version: 2
-  release:
+  build_and_release:
     jobs:
       - install
       - build:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ This project is forked from [Slate](https://github.com/lord/slate).
 
 1. [Run the project locally](#run-the-project-locally)
 2. Do your changes (most of the text is in `/source/includes` folder). Learn more about [editing Slate markdown](https://github.com/lord/slate/wiki/Markdown-Syntax)
-3. Create pull request. Merge. Go to `master` branch and pull. **Deploy** (just run `./deploy.sh`)
+3. Create a pull request.
+
+Your changes will be deployed automatically when merged to master.
 
 For more detailed guides etc go to [Slate documentation](https://github.com/lord/slate).
 

--- a/source/includes/reference/_terms.md
+++ b/source/includes/reference/_terms.md
@@ -34,6 +34,6 @@ No authentication is required for this endpoint.
 
 
 ### Response
-Terms and conditions in HTML format.
+Terms and conditions in HTML format
 
 


### PR DESCRIPTION
Integrate with CircleCI - to simplify deployment.

No need to run `./deploy.sh` manually anymore.