### PR TITLE
Authorization updates

### DIFF
--- a/source/includes/_banks.md
+++ b/source/includes/_banks.md
@@ -6,7 +6,7 @@ TransferWise uses standard OAuth 2.0 protocol for authentication and authorizati
 Once our partnership begins, we’ll send you API access credentials for the sandbox environment consisting of a Client ID and a Client Secret.
 The credentials are needed to complete the authorisation_code grant type of OAuth 2.0 through which the customer will allow your application to be able to act on their behalf.
 We also need *redirect_url* from your technical team so that we can limit our callbacks to only that URL, this is URL that we will forward users to after successfully granting your application access to their TransferWise account. Specifying this explicitly makes the integration more secure.
-[OAuth 2.0: The Complete Guide](https://auth0.com/blog/oauth2-the-complete-guide/) is a great way to refresh your knowledge about the protocol itself.
+<a href="https://auth0.com/docs/protocols/oauth2" target="_blank" rel="noopener noreferrer">This article about OAuth 2.0 framework</a> is a great way to refresh your knowledge about the protocol itself.
 
 ### SANDBOX and LIVE environments
 

--- a/source/includes/_banks.md
+++ b/source/includes/_banks.md
@@ -86,11 +86,11 @@ Your website or app opens the following url in the user's browser.
 
 Sandbox:  
 `
-https://sandbox.transferwise.tech/oauth/authorize?response_type=code&client_id=<your api client id>&redirect_uri=https://www.yourbank.com
+https://sandbox.transferwise.tech/oauth/authorize/?response_type=code&client_id=<your api client id>&redirect_uri=https://www.yourbank.com
 ` <br/>
 Live:  
 `
-https://transferwise.com/oauth/authorize?response_type=code&client_id=<your api client id>&redirect_uri=https://www.yourbank.com
+https://transferwise.com/oauth/authorize/?response_type=code&client_id=<your api client id>&redirect_uri=https://www.yourbank.com
 `
 
 Replace *your-api-client-id* and *redirect-uri* with your specific values. 

--- a/source/includes/_connected-apps.md
+++ b/source/includes/_connected-apps.md
@@ -11,7 +11,7 @@ TransferWise uses standard OAuth 2.0 protocol for authentication and authorizati
 Once our partnership begins, we’ll send you API access credentials for the sandbox environment consisting of a Client ID and a Client Secret.
 The credentials are needed to complete the authorisation_code grant type of OAuth 2.0 through which the customer will allow your application to be able to act on their behalf.
 We also need *redirect_url* from your technical team so that we can limit our callbacks to only that URL, this is URL that we will forward users to after successfully granting your application access to their TransferWise account. Specifying this explicitly makes the integration more secure.
-[OAuth 2.0: The Complete Guide](https://auth0.com/blog/oauth2-the-complete-guide/) is a great way to refresh your knowledge about the protocol itself.
+<a href="https://auth0.com/docs/protocols/oauth2" target="_blank" rel="noopener noreferrer">This article about OAuth 2.0 framework</a> is a great way to refresh your knowledge about the protocol itself.
 
 ### SANDBOX and LIVE environments
 

--- a/source/includes/_connected-apps.md
+++ b/source/includes/_connected-apps.md
@@ -40,11 +40,11 @@ Your website or app opens the following url in the user's browser.
 
 Sandbox:  
 `
-https://sandbox.transferwise.tech/oauth/authorize?response_type=code&client_id=<your api client id>&redirect_uri=https://www.yourapp.com
+https://sandbox.transferwise.tech/oauth/authorize/?response_type=code&client_id=<your api client id>&redirect_uri=https://www.yourapp.com
 ` <br/>
 Live:  
 `
-https://transferwise.com/oauth/authorize?response_type=code&client_id=<your api client id>&redirect_uri=https://www.yourapp.com
+https://transferwise.com/oauth/authorize/?response_type=code&client_id=<your api client id>&redirect_uri=https://www.yourapp.com
 `
 
 Replace *your-api-client-id* and *redirect-uri* with your specific values. 


### PR DESCRIPTION
**Changes:**

1. Added `/` before query params. Why? Because our public-proxy will add it anyway when you don't have it.
2. We linked to "Oauth 2.0: The Complete Guide", but this page doesn't exist, and it redirects to https://auth0.com/blog/on-the-nature-of-oauth2-scopes/. But this one seems to be more about scopes, not general overview. So now I'm replacing the article with: https://auth0.com/docs/protocols/oauth2

This seems to be the page we used to link to:
![Screenshot 2019-10-10 at 12 20 11](https://user-images.githubusercontent.com/39053304/66557617-df73c100-eb5a-11e9-9bc3-30a174e0eb8a.png)
