### PR TITLE
Moving 3pp/connected apps out of public docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ All contributions are welcome and encouraged!
 
 This project is forked from [Slate](https://github.com/lord/slate).
 
+For partner-usecases (third party payments, connected apps) refer to https://transferwise.github.io/api-docs-partners/
+
 ## How to edit the docs?
 
 1. [Run the project locally](#run-the-project-locally)

--- a/source/includes/_connected-apps.md
+++ b/source/includes/_connected-apps.md
@@ -1,6 +1,12 @@
 # Connected Apps Guide
 
-This guide described how your application can request TransferWise customers to grant access to their account. 
+## Connected Applications
+
+With Connected Applications, you can let your customers connect their TransferWise accounts to your product. Say you’re an accounting software – doing this could let your customers automate reconciliation. If you’re a payroll company, you could push customer payments right into TransferWise. You could even push TransferWise notifications through your app. Whatever you want to build, you likely could!
+
+We need to take a deeper look into your application use case and the added value it will bring to our joint customers in order to authorise such an integration. So before starting the technical work please contact our [sales team](https://transferwise.com/gb/business/contact) for more info on how to get started.
+
+This guide describes how your application can request TransferWise customers to grant access to their account. 
 
 Note that asking TransferWise users to copy-paste their Transferwise API tokens directly into your application is a violation of our security policy.  So please only use proper OAuth authorization flow as described below.
  

--- a/source/includes/_third-party-payouts.md
+++ b/source/includes/_third-party-payouts.md
@@ -1,5 +1,17 @@
 # Third-Party Payouts Guide
 
+Third-Party Payouts allows marketplaces and financial institutions (banks and payment service providers) to use TransferWise as a payout option for their customers.
+It’s different from Payouts since it doesn’t require your company to be the originator of payments.
+Instead, TransferWise will act as a third-party to your customers when they initiate a payment through your site.  
+
+All the above listed payouts and account automation benefits are also true for third-party payouts service. You can build payment services to your customers on top of TransferWise payment platform that enables your customers to send cross-border payouts to 40+ currencies in 70+ countries.
+
+In addition there will also be a dedicated account manager who will be your primary contact
+to solve all questions and support issues should these arise.
+
+Please note that subscribing to third party payouts service requires your company to complete enhanced due diligence process performed by TransferWise compliance team.
+Please contact our [sales team](https://transferwise.com/gb/business/contact) for more info how to get started.
+
 This guide is an extension to [Payouts Guide](#payouts-guide) and it only outlines small differences between creating regular transfers and creating third party transfers.
 Please read through regular Payouts Guide first.  
 

--- a/source/includes/_usecases.md
+++ b/source/includes/_usecases.md
@@ -15,10 +15,8 @@ https://api.transferwise.com
 Welcome to the TransferWise API documentation. You can explore the different ways to use our API and choose the right one for you below.
 
 * [Payouts and Account Automation](#transferwise-api-payouts-and-account-automation)
-* [Third-Party Payouts](#transferwise-api-third-party-payouts)
 * [Banks](#transferwise-api-banks)
 * [Affiliates](#transferwise-api-affiliates)
-* [Connected Applications](#transferwise-api-connected-applications)
 * [Receive Money](#transferwise-api-receive-money)
 * [Open Banking API](#open-banking-api)
 
@@ -38,22 +36,6 @@ You can:
 </ul>
 
 Our [Payouts Guide](#payouts-guide) will help you get started with the technical integration.
-
-## Third-Party Payouts
-
-Third-Party Payouts allows marketplaces and financial institutions (banks and payment service providers) to use TransferWise as a payout option for their customers.
-It’s different from Payouts since it doesn’t require your company to be the originator of payments.
-Instead, TransferWise will act as a third-party to your customers when they initiate a payment through your site.  
-
-All the above listed payouts and account automation benefits are also true for third-party payouts service. You can build payment services to your customers on top of TransferWise payment platform that enables your customers to send cross-border payouts to 40+ currencies in 70+ countries.
-
-In addition there will also be a dedicated account manager who will be your primary contact
-to solve all questions and support issues should these arise.
-
-Please note that subscribing to third party payouts service requires your company to complete enhanced due diligence process performed by TransferWise compliance team.
-Please contact our [sales team](https://transferwise.com/gb/business/contact) for more info how to get started.
-
-Our [Third-Party Payouts Guide](#third-party-payouts-guide) will help you get started with the technical integration.
 
 ## Banks
 
@@ -109,14 +91,6 @@ The TransferWise API lets you to:
 </ul>
 
 The [Affiliates Integration Guide](#affiliates-integration-guide) helps you get started with the technical integration.
-
-## Connected Applications
-
-With Connected Applications, you can let your customers connect their TransferWise accounts to your product. Say you’re an accounting software – doing this could let your customers automate reconciliation. If you’re a payroll company, you could push customer payments right into TransferWise. You could even push TransferWise notifications through your app. Whatever you want to build, you likely could!
-
-We need to take a deeper look into your application use case and the added value it will bring to our joint customers in order to authorise such an integration. So before starting the technical work please contact our [sales team](https://transferwise.com/gb/business/contact) for more info on how to get started.
-
-Our [Connected Apps Guide](#connected-apps-guide) gives you an overview of required technical integration work.
 
 ## Receive Money
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -9,10 +9,8 @@ search: true
 includes:
   - usecases
   - payouts
-  - third-party-payouts
   - banks
   - affiliates
-  - connected-apps
   - openbanking
   - contact-us
   - full-reference-separator


### PR DESCRIPTION
Removing partner usecases from public docs, they will be available @ https://transferwise.github.io/api-docs-partners/