### PR TITLE
Setting isOwnedByCustomer to not be nullable on responses

### DIFF
--- a/source/includes/reference/_recipients.md
+++ b/source/includes/reference/_recipients.md
@@ -153,7 +153,7 @@ currency              | 3 character currency code                             | 
 type                  | Recipient type                                        | Text          | false
 profile               | Personal or business profile id                       | Integer       | false
 accountHolderName     | Recipient full name                                   | Text          | false
-ownedByCustomer       | Whether this account is owned by the sending user     | Text          | true
+ownedByCustomer       | Whether this account is owned by the sending user     | Boolean       | true
 details               | Currency specific fields                              | Object        | false
 details.legalType     | Recipient legal type: PRIVATE or BUSINESS             | Text          | false
 details.sortCode      | Recipient bank sort code (GBP example)                | Text          | false
@@ -175,7 +175,7 @@ acccountHolderName    | Recipient full name                                   | 
 currency              | 3 character country code                              | Text          | false
 country               | 2 character currency code                             | Text          | false
 type                  | Recipient type                                        | Text          | false
-ownedByCustomer       | Whether this account is owned by the sending user     | Text          | true
+ownedByCustomer       | Whether this account is owned by the sending user     | Boolean       | false
 details               | Currency specific fields                              | Object        | false
 details.legalType     | Recipient legal type                                  | Text          | true
 details.sortCode      | Recipient bank sort code (GBP example)                | Text          | Currency Dependent


### PR DESCRIPTION
ownedByCustomer is properly set as not-nullable (we will always return it in the response.  If it's null in the database, we return false).

Also correctly setting the field to be of type boolean (it does not include quotes in the response for this field).